### PR TITLE
Fixes the issue where calling writeAsync results in a DynamoDB ValidationException

### DIFF
--- a/src/aggregate/repository.ts
+++ b/src/aggregate/repository.ts
@@ -59,6 +59,11 @@ export class Repository<T extends AggregateRoot> implements IRepository<T> {
     const changes = aggregate.getChanges();
     logger.debug("Changes.", changes);
 
+    if (changes.length === 0) {
+      logger.debug("No changes to write for aggregate.", aggregate.id);
+      return;
+    }
+
     const expectedVersion = aggregate.getExpectedVersion();
     logger.debug("Expected Version.", expectedVersion);
 

--- a/tests/aggregate/repository.test.ts
+++ b/tests/aggregate/repository.test.ts
@@ -191,6 +191,26 @@ describe("Repository Tests", () => {
       await expect(repo.writeAsync(ar2)).rejects.toThrow();
     }
   });
+
+  it("should handle writeAsync with no changes without throwing", async () => {
+    // arrange
+    const { id, repo } = await setupAndExecuteAsync(false);
+
+    // act
+    // read back the aggregate
+    const ar = await repo.readAsync(id);
+
+    // assert
+    // writing without making changes should not throw
+    if (ar) {
+      await expect(repo.writeAsync(ar)).resolves.not.toThrow();
+
+      // verify the aggregate still has no uncommitted changes
+      expect(ar.getChanges()).toHaveLength(0);
+    } else {
+      fail("AggregateRoot not found in database.");
+    }
+  });
 });
 
 // helper methods


### PR DESCRIPTION
Fixes the issue where calling writeAsync on an aggregate with no  uncommitted changes would result in a DynamoDB ValidationException:
   "Value '[]' at 'transactItems' failed to satisfy constraint:
   Member must have length greater than or equal to 1"

   Changes:
   - Added guard clause in writeAsync to check if changes array is empty
   - Returns early (no-op) when there are no changes to persist
   - Added test case to verify writeAsync handles no-change scenario
   - Prevents unnecessary DynamoDB transactWrite calls

   This makes writeAsync idempotent and safe to call multiple times,
   which is important when aggregates are loaded and saved without
   modifications.