### PR TITLE
fix: guard changeProps against null/undefined allow-listed fields (1.0.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-aggregates",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-aggregates",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",

--- a/src/aggregate/repository.ts
+++ b/src/aggregate/repository.ts
@@ -89,7 +89,14 @@ export class Repository<T extends AggregateRoot> implements IRepository<T> {
 
     for (let index = 0; index < encryptedProps.length; index++) {
       const propertyName = encryptedProps[index];
-      props[propertyName] = f(props[propertyName], encryptionKey);
+      const value = props[propertyName];
+      // An allow-listed field may be absent on a given event (e.g.
+      // MessageCreated lists both text and imageUrl but populates only one).
+      // Skip absent fields so encrypt/decrypt is never called with undefined,
+      // and keep absent as absent (do NOT coerce to "").
+      if (value !== undefined && value !== null) {
+        props[propertyName] = f(value, encryptionKey);
+      }
     }
     return props;
   };

--- a/tests/aggregate/repository.test.ts
+++ b/tests/aggregate/repository.test.ts
@@ -192,6 +192,68 @@ describe("Repository Tests", () => {
     }
   });
 
+  it("should not throw when encrypting an event with an absent allow-listed field", async () => {
+    // arrange
+    // TestMessageCreated allow-lists both text and imageUrl, but a text-only
+    // message leaves imageUrl undefined. encrypt(undefined, key) must not run.
+    const id = v4();
+    const key = "key";
+    const { repo } = setupRepoAndDynamoDB();
+    const ar = TestAggregateRoot.create(id, "msg-ar");
+    ar.createMessage("hello world");
+
+    // act / assert
+    await expect(repo.writeAsync(ar, key)).resolves.not.toThrow();
+  });
+
+  it("should not throw when an allow-listed field is null", async () => {
+    // arrange
+    const id = v4();
+    const key = "key";
+    const { repo } = setupRepoAndDynamoDB();
+    const ar = TestAggregateRoot.create(id, "msg-ar");
+    // image-only message: text is explicitly null
+    ar.createMessage(null as unknown as undefined, "https://example.com/i.png");
+
+    // act / assert
+    await expect(repo.writeAsync(ar, key)).resolves.not.toThrow();
+  });
+
+  it("should round-trip an event with one populated and one absent allow-listed field", async () => {
+    // arrange
+    const id = v4();
+    const key = "key";
+    const text = "secret message text";
+    const { ddbc, repo } = setupRepoAndDynamoDB();
+    const ar = TestAggregateRoot.create(id, "msg-ar");
+    ar.createMessage(text); // imageUrl absent
+
+    // act
+    await repo.writeAsync(ar, key);
+
+    // the populated allow-listed field is encrypted at rest
+    const dc = DynamoDBDocumentClient.from(ddbc);
+    const { Item } = await dc.send(
+      new GetCommand({
+        TableName: "test-service-event-dev",
+        Key: { aggregateId: id, aggregateVersion: 1 },
+      })
+    );
+    expect(Item?.data.text).not.toBe(text);
+    expect(Item?.data.imageUrl).toBeUndefined();
+
+    // read back: present field decrypts, absent stays absent
+    const readAr = await repo.readAsync(id, key);
+
+    // assert
+    if (readAr) {
+      expect(readAr.messageText).toBe(text);
+      expect(readAr.messageImageUrl).toBeUndefined();
+    } else {
+      fail("AggregateRoot not found in database.");
+    }
+  });
+
   it("should handle writeAsync with no changes without throwing", async () => {
     // arrange
     const { id, repo } = await setupAndExecuteAsync(false);

--- a/tests/test-objects/events/test-message-created.ts
+++ b/tests/test-objects/events/test-message-created.ts
@@ -1,0 +1,14 @@
+import { EventBase } from "../../../src";
+
+// MessageCreated-shaped: both text and imageUrl are PII (allow-listed for
+// encryption) but any given message populates only one of them.
+export class TestMessageCreated extends EventBase {
+  public static typename = "TestMessageCreated";
+  constructor(
+    public readonly id: string,
+    public readonly text?: string,
+    public readonly imageUrl?: string
+  ) {
+    super(TestMessageCreated.typename, ["text", "imageUrl"]);
+  }
+}

--- a/tests/test-objects/index.ts
+++ b/tests/test-objects/index.ts
@@ -4,3 +4,4 @@ export * from "./test-entity";
 export * from "./events/test-aggregate-root-created";
 export * from "./events/test-aggregate-root-name-changed";
 export * from "./events/test-entity-created";
+export * from "./events/test-message-created";

--- a/tests/test-objects/test-aggregate-root.ts
+++ b/tests/test-objects/test-aggregate-root.ts
@@ -5,6 +5,7 @@ import { TestEntityCreated } from "./events/test-entity-created";
 import { TestAggregateRootNameChanged } from "./events/test-aggregate-root-name-changed";
 import { TestAggregateRootCreated } from "./events/test-aggregate-root-created";
 import { TestEntityNameChanged } from "./events/test-entity-name-changed";
+import { TestMessageCreated } from "./events/test-message-created";
 
 export class TestAggregateRoot extends AggregateRoot {
   private _id: string;
@@ -25,6 +26,16 @@ export class TestAggregateRoot extends AggregateRoot {
   private _created: string;
   public get created(): string {
     return this._created;
+  }
+
+  private _messageText?: string;
+  public get messageText(): string | undefined {
+    return this._messageText;
+  }
+
+  private _messageImageUrl?: string;
+  public get messageImageUrl(): string | undefined {
+    return this._messageImageUrl;
   }
 
   constructor() {
@@ -68,6 +79,11 @@ export class TestAggregateRoot extends AggregateRoot {
       (e: DummyEntityCreated) => {
       }
     );
+
+    this.register(TestMessageCreated.typename, (e: TestMessageCreated) => {
+      this._messageText = e.text;
+      this._messageImageUrl = e.imageUrl;
+    });
   }
 
   public static factory = (): TestAggregateRoot => {
@@ -110,6 +126,10 @@ export class TestAggregateRoot extends AggregateRoot {
     }
 
     return id;
+  };
+
+  public createMessage = (text?: string, imageUrl?: string) => {
+    this.applyChange(new TestMessageCreated(this.id, text, imageUrl));
   };
 
   public changeNameTestEntity = (id: string, name: string) => {


### PR DESCRIPTION
## Summary

`Repository.changeProps` (`src/aggregate/repository.ts`) iterated each event's `encryptedProps` allow-list and applied the transform to every listed field **without guarding for an absent value**:

```ts
props[propertyName] = f(props[propertyName], encryptionKey); // f = encrypt | decrypt
```

When a listed field was absent at runtime, `encrypt(undefined, key)` threw `TypeError: The "data" argument must be of type string...`.

`MessageCreated` correctly allow-lists **both** `text` and `imageUrl` (both PII), but a given message populates only one:
- text-only → `imageUrl` undefined → crash
- image-only → `text` undefined → crash
- template → both undefined → crash

The moment encryption is enabled, the first such conversation write crashes.

## Fix

Guard the transform to skip `null`/`undefined` fields. Applied in `changeProps`, which is shared by **both** the encrypt write-path (~L115) and the decrypt read-path (~L180), so the guard is symmetric: a field never encrypted at write time is also absent on read and is skipped identically. Absent stays absent — no coercion to `""`.

## Tests

Added to `tests/aggregate/repository.test.ts` (with a new `TestMessageCreated`-shaped event allow-listing `text` + `imageUrl`):
- encrypt write with an absent allow-listed field → no throw
- same for an explicitly `null` field
- encrypt→decrypt round-trip with one populated + one absent field → present field encrypts at rest and decrypts back; absent stays absent
- existing fully-populated round-trip stays green

All 26 tests pass locally.

## Release

**No manual version bump in this PR** — `package.json` stays at 1.0.1. The Release workflow (`.github/workflows/release.yml`, `workflow_dispatch`) owns versioning: it runs `yarn version --patch`, commits the bump, tags, releases, and npm-publishes. The **1.0.2** release happens by dispatching the Release workflow **after** this merges. The encryption bug is present in both published 1.0.0 and 1.0.1.

**Not a draft** — Ian reviews the library change and authorizes the release (do not self-merge). This feeds QuidPro prod PII encryption.

Fixes es-4w2. Blocks qp-389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)