### PR TITLE
ci: publish via npm OIDC Trusted Publishing (drop NPM_TOKEN)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ jobs:
     permissions:
       contents: write
       packages: write
-      
+      id-token: write
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -34,7 +35,13 @@ jobs:
         node-version: '20.x'
         cache: 'yarn'
         registry-url: 'https://registry.npmjs.org'
-        
+
+    - name: Upgrade npm for OIDC Trusted Publishing
+      # OIDC trusted publishing requires npm >= 11.5.1; node 20.x ships npm 10.
+      run: |
+        npm install -g npm@latest
+        npm --version
+
     - name: Configure git
       run: |
         git config --global user.name "github-actions[bot]"
@@ -108,6 +115,6 @@ jobs:
         prerelease: ${{ contains(steps.version.outputs.new_version, '-') }}
         
     - name: Publish to npm
-      run: yarn publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Authenticates via OIDC Trusted Publishing (no NPM_TOKEN). Requires the
+      # one-time Trusted Publisher config on npmjs.com — see PR description.
+      run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

Migrates `.github/workflows/release.yml` from a long-lived `NPM_TOKEN` to **npm OIDC Trusted Publishing**, so there's no token to rotate again.

Changes (release job only; version-bump/commit/tag/GitHub-Release steps untouched):
1. Added `id-token: write` to the `permissions:` block (kept `contents: write` + `packages: write`).
2. Added a step after Setup Node.js to `npm install -g npm@latest` + `npm --version` — OIDC trusted publishing needs **npm >= 11.5.1**, and node 20.x ships npm 10.
3. Replaced the publish step: `yarn publish --access public` → `npm publish --access public --provenance`, and removed its `env` block (`NODE_AUTH_TOKEN` / `NPM_TOKEN`) entirely. (Bonus: `npm publish` also avoids yarn classic's spurious extra version bump.)

The `NPM_TOKEN` repo secret is intentionally **left in place** (harmless; not referenced anymore).

## ⚠️ Required one-time manual prerequisite (Ian)

OIDC will **not authenticate until a Trusted Publisher is configured on npm**. Before the next release, on npmjs.com:

- Go to the **es-aggregates** package → **Settings** → **Trusted Publisher**
- Add a **GitHub Actions** publisher:
  - Repository: `ianhorton/es-aggregates`
  - Workflow file: `release.yml`
  - Environment: (only if the workflow uses one — it does not, so leave blank)

**Until this is set, dispatching the Release workflow will fail at the publish step.** It must be configured before the next release.

## Notes
- Ready-for-review (not a draft). Do not self-merge; do not dispatch the workflow.
- Separate from the changeProps fix (PR #9, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)