### PR TITLE
fix(repository): only stamp encryptedProps for fields actually encrypted (qp-qdwt)

### DIFF
--- a/src/aggregate/repository.ts
+++ b/src/aggregate/repository.ts
@@ -78,15 +78,21 @@ export class Repository<T extends AggregateRoot> implements IRepository<T> {
     aggregate.clearChanges();
   };
 
+  // Applies f (encrypt/decrypt) to each allow-listed field that is actually
+  // present, and reports back exactly which fields it transformed. The caller
+  // derives the persisted encryptedProps marker from `transformed`, so the
+  // marker can never desync from what was really encrypted (single source of
+  // truth — the presence check lives here and nowhere else).
   private changeProps = (
     props: any,
     f: (data: string, key: string) => string,
     encryptionKey?: string,
     encryptedProps?: string[]
-  ): {} => {
-    if (encryptionKey === undefined) return props;
-    if (encryptedProps === undefined) return props;
+  ): { data: {}; transformed: string[] } => {
+    if (encryptionKey === undefined) return { data: props, transformed: [] };
+    if (encryptedProps === undefined) return { data: props, transformed: [] };
 
+    const transformed: string[] = [];
     for (let index = 0; index < encryptedProps.length; index++) {
       const propertyName = encryptedProps[index];
       const value = props[propertyName];
@@ -96,9 +102,10 @@ export class Repository<T extends AggregateRoot> implements IRepository<T> {
       // and keep absent as absent (do NOT coerce to "").
       if (value !== undefined && value !== null) {
         props[propertyName] = f(value, encryptionKey);
+        transformed.push(propertyName);
       }
     }
-    return props;
+    return { data: props, transformed };
   };
 
   private transactWriteAsync = async (
@@ -113,41 +120,29 @@ export class Repository<T extends AggregateRoot> implements IRepository<T> {
       const event = changes[index];
       const { eventType, timestamp, encryptedProps, ...otherProps } = event;
 
-      // Only stamp the encryptedProps marker for fields we ACTUALLY encrypt.
-      // With no key (encryption off) changeProps leaves the data plaintext, so
-      // persisting the marker would falsely claim the fields are ciphertext —
-      // which corrupts the read path (it would run decrypt() on plaintext when
-      // rehydrating) and defeats any marker-trusting backfill (it would skip
-      // plaintext as "already encrypted"). Plaintext events therefore carry no
-      // marker at all. We also drop fields that are absent on this event (an
-      // allow-listed field may be unpopulated, e.g. a MessageCreated with text
-      // but no imageUrl) so the marker reflects exactly what was encrypted —
-      // mirroring changeProps, which skips absent values.
-      const otherPropsRecord = otherProps as Record<string, unknown>;
-      const persistedEncryptedProps =
-        encryptionKey === undefined || encryptedProps === undefined
-          ? undefined
-          : encryptedProps.filter(
-              (name) =>
-                otherPropsRecord[name] !== undefined &&
-                otherPropsRecord[name] !== null
-            );
+      // Stamp the encryptedProps marker from exactly what changeProps actually
+      // encrypted. With no key (encryption off) changeProps leaves the data
+      // plaintext and reports nothing transformed, so persisting a marker would
+      // falsely claim the fields are ciphertext — corrupting the read path (it
+      // would run decrypt() on plaintext when rehydrating) and defeating any
+      // marker-trusting backfill (it would skip plaintext as "already
+      // encrypted"). Plaintext events therefore carry no marker at all. Absent
+      // allow-listed fields (e.g. a MessageCreated with text but no imageUrl)
+      // are likewise excluded, because changeProps does not transform them.
+      const { data, transformed } = this.changeProps(
+        otherProps,
+        encrypt,
+        encryptionKey,
+        encryptedProps
+      );
 
       const persistedEvent: IPersistedEvent = {
         aggregateId,
         eventType,
         timestamp,
         aggregateVersion: expectedVersion + index,
-        encryptedProps:
-          persistedEncryptedProps && persistedEncryptedProps.length > 0
-            ? persistedEncryptedProps
-            : undefined,
-        data: this.changeProps(
-          otherProps,
-          encrypt,
-          encryptionKey,
-          encryptedProps
-        ),
+        encryptedProps: transformed.length > 0 ? transformed : undefined,
+        data,
       };
 
       const item = marshall(persistedEvent, { removeUndefinedValues: true });
@@ -207,7 +202,7 @@ export class Repository<T extends AggregateRoot> implements IRepository<T> {
     if (items.length > 0) {
       const events = items.map(
         ({ eventType, timestamp, encryptedProps, data }: any) => {
-          const decryptedData = this.changeProps(
+          const { data: decryptedData } = this.changeProps(
             data,
             decrypt,
             encryptionKey,

--- a/src/aggregate/repository.ts
+++ b/src/aggregate/repository.ts
@@ -113,12 +113,35 @@ export class Repository<T extends AggregateRoot> implements IRepository<T> {
       const event = changes[index];
       const { eventType, timestamp, encryptedProps, ...otherProps } = event;
 
+      // Only stamp the encryptedProps marker for fields we ACTUALLY encrypt.
+      // With no key (encryption off) changeProps leaves the data plaintext, so
+      // persisting the marker would falsely claim the fields are ciphertext —
+      // which corrupts the read path (it would run decrypt() on plaintext when
+      // rehydrating) and defeats any marker-trusting backfill (it would skip
+      // plaintext as "already encrypted"). Plaintext events therefore carry no
+      // marker at all. We also drop fields that are absent on this event (an
+      // allow-listed field may be unpopulated, e.g. a MessageCreated with text
+      // but no imageUrl) so the marker reflects exactly what was encrypted —
+      // mirroring changeProps, which skips absent values.
+      const otherPropsRecord = otherProps as Record<string, unknown>;
+      const persistedEncryptedProps =
+        encryptionKey === undefined || encryptedProps === undefined
+          ? undefined
+          : encryptedProps.filter(
+              (name) =>
+                otherPropsRecord[name] !== undefined &&
+                otherPropsRecord[name] !== null
+            );
+
       const persistedEvent: IPersistedEvent = {
         aggregateId,
         eventType,
         timestamp,
         aggregateVersion: expectedVersion + index,
-        encryptedProps,
+        encryptedProps:
+          persistedEncryptedProps && persistedEncryptedProps.length > 0
+            ? persistedEncryptedProps
+            : undefined,
         data: this.changeProps(
           otherProps,
           encrypt,

--- a/tests/aggregate/repository.test.ts
+++ b/tests/aggregate/repository.test.ts
@@ -130,6 +130,57 @@ describe("Repository Tests", () => {
     }
   });
 
+  it("should stamp encryptedProps only for fields actually encrypted (with key)", async () => {
+    // arrange
+    const { ddbc, id } = await setupAndExecuteAsync(true);
+    const dc = DynamoDBDocumentClient.from(ddbc);
+
+    // act
+    const { Item } = await dc.send(
+      new GetCommand({
+        TableName: "test-service-event-dev",
+        Key: { aggregateId: id, aggregateVersion: 0 },
+      })
+    );
+
+    // assert
+    // TestAggregateRootCreated allow-lists ["name"] and name is populated, so
+    // the marker reflects exactly the field that was encrypted at rest.
+    if (Item) {
+      expect(Item.encryptedProps).toEqual(["name"]);
+    } else {
+      fail("Event not found in database.");
+    }
+  });
+
+  it("should NOT stamp encryptedProps when written without a key (plaintext)", async () => {
+    // arrange
+    // qp-389/qp-qdwt regression: the write path used to stamp the static
+    // encryptedProps allow-list onto EVERY event, even when no key was supplied
+    // and the data stayed plaintext. That false marker is a data-corruption
+    // landmine — once encryption is later enabled the read path would run
+    // decrypt() on plaintext — and it made marker-trusting backfills skip the
+    // plaintext as "already encrypted". A plaintext event must carry no marker.
+    const { ddbc, id, name } = await setupAndExecuteAsync(false);
+    const dc = DynamoDBDocumentClient.from(ddbc);
+
+    // act
+    const { Item } = await dc.send(
+      new GetCommand({
+        TableName: "test-service-event-dev",
+        Key: { aggregateId: id, aggregateVersion: 0 },
+      })
+    );
+
+    // assert
+    if (Item) {
+      expect(Item.encryptedProps).toBeUndefined();
+      expect(Item.data.name).toBe(name); // data is genuinely plaintext
+    } else {
+      fail("Event not found in database.");
+    }
+  });
+
   it("should return and AggregateRoot with unencrypted properties", async () => {
     // arrange
     const { repo, id, key, name } = await setupAndExecuteAsync(true);


### PR DESCRIPTION
## The bug

`Repository.transactWriteAsync` persisted each event's **static `encryptedProps` allow-list** onto every persisted row — *unconditionally* — while `changeProps` correctly skipped encryption when no key was supplied (`if (encryptionKey === undefined) return props`). The result: **plaintext data carrying a marker that falsely claims the fields are ciphertext.**

Found via the qp-389 dev backfill. Evidence (dev, encryption OFF):
- `UserCreated` → `data.phoneNumber = "+447779322535"` (plaintext) but `encryptedProps = ["phoneNumber"]`
- `MessageCreated` → `data.text` plaintext but `encryptedProps = ["text","imageUrl"]`

### Two consequences
1. **Read-corruption landmine** — the read path decrypts exactly the fields named in `encryptedProps`. The moment a key is later present, rehydrating any event written during a key-less period runs `decrypt()` on plaintext → reads break for every such event.
2. **Backfill false-negative** — a backfill that trusts the marker treats plaintext as already-encrypted and skips it (0 events to rewrite).

## The fix

Derive the persisted marker from what was **actually** encrypted:
- **No key** → no marker (`undefined`, dropped by `marshall`'s `removeUndefinedValues`). Plaintext events carry no `encryptedProps`, so the read layer is a no-op on them — matching the design intent.
- **With a key** → list only allow-listed fields **present** on the event, mirroring `changeProps` (which skips absent values). So a text-only `MessageCreated` is marked `["text"]`, not `["text","imageUrl"]`.

## Tests

Adds two regression tests to `repository.test.ts`:
- write **without** a key → persisted `encryptedProps` is `undefined` and `data.name` is genuinely plaintext;
- write **with** a key → `encryptedProps` is `["name"]` (only the encrypted field).

Full suite green locally against embedded DynamoDB Local: **28/28**.

## Release / consumers

No manual version bump here — the `Release` workflow (`workflow_dispatch`) does the `yarn version` + OIDC publish on `main`. After merge: run **Release → patch** (→ `1.0.3`), then bump `es-aggregates` `1.0.2 → 1.0.3` in `chat-platform` (5 package.jsons) and in QuidPro.

**Do not merge yet** — `--no-merge` for Ian. Refs qp-389 / qp-qdwt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)