### PR TITLE
fix(release): force-clean working tree before recovery tag checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,20 @@ jobs:
         set -euo pipefail
         TAG="${{ steps.version.outputs.tag_name }}"
         git fetch origin "refs/tags/$TAG:refs/tags/$TAG"
-        git checkout "refs/tags/$TAG"
+        # The "Determine next version" step bumps package.json in the working
+        # tree (via `npm version`) to feed the normal path's release commit. On
+        # the recovery path we don't want that edit — the tagged commit already
+        # carries the correct version — so force the checkout: a plain
+        # `git checkout <tag>` ABORTS rather than overwrite the dirty package.json
+        # ("Your local changes would be overwritten"). `-f` discards any tracked
+        # working-tree changes, and `git reset --hard` + `git clean -fd` leave
+        # the tree byte-for-byte equal to the tag so no later git step in the
+        # recovery path can trip over leftover state.
+        git checkout -f "refs/tags/$TAG"
+        git reset --hard "refs/tags/$TAG"
+        git clean -fd
+        echo "Working tree at $TAG:"
+        git status --porcelain || true
 
     - name: Build project
       run: yarn build


### PR DESCRIPTION
Fixes the **first live Release run** failure (es-4rt). npm is still 1.0.2 because the recovery path aborted.

## Root cause
The *Determine next version* step bumps `package.json` in the working tree (via `npm version`) to feed the normal path's release commit. When a run enters **recovery** (tag `v1.0.3` exists but isn't on npm), the *Check out existing tag* step ran a plain `git checkout refs/tags/v1.0.3`, which refuses to overwrite the dirty `package.json`:

```
error: Your local changes to the following files would be overwritten by checkout:
	package.json
Please commit your changes or stash them before you switch branches. Aborting
```

The **normal** path is unaffected — `git checkout -b <branch>` carries the dirty change into the new branch and then commits it.

## Fix
Force the recovery checkout and pin the tree to the tag:
```sh
git checkout -f "refs/tags/$TAG"
git reset --hard "refs/tags/$TAG"
git clean -fd
```
The tagged commit already carries the correct version, so discarding the working-tree edit is exactly right; pinning to the tag means no later git step in the recovery path can trip over leftover state.

**Verified locally** (minimal repro): a plain `git checkout <tag>` with a dirty file that differs from the tag aborts with the exact error above (exit 1); the forced sequence lands the tag's content with a clean tree.

## Whole-path audit (no whack-a-mole)
Checked every git operation on the recovery + idempotent-reconcile path for a clean-tree assumption. The recovery checkout was the only `checkout`/`switch`. The reconcile step uses only `git ls-remote` / `git fetch` / `git show` / `git push` — none of which touch the working tree. `npm publish` reads the (now clean) checked-out tag tree.

## Converges from the current partial state
tag `v1.0.3` + GitHub Release + branch `release/v1.0.3` (b22f9be) exist, **no** reconcile PR, npm=1.0.2. A re-run now:
1. recovery=true (tag exists, not on npm) → **checks out the tag cleanly** (this fix),
2. reconcile (idempotent): tag/Release present → skip; `main`@1.0.2 ≠ 1.0.3 → branch present → skip push, **no open PR → create it** + dispatch checks + arm `--merge` auto-merge,
3. `npm publish` 1.0.3 via OIDC **last**.

Result: 1.0.3 on npm, reconcile PR merges (main → 1.0.3), tag reachable from main.

`--no-merge` — Ian merges, then re-runs Release(patch) for the live-fire validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)